### PR TITLE
Minor chat changes

### DIFF
--- a/SRC/LUA/CHAT.LUA
+++ b/SRC/LUA/CHAT.LUA
@@ -68,8 +68,8 @@ local chat_fmts = {
 }
 
 local function CHAT_TeamSay(s, m) --Sender (player_t), Message
-	m = m:gsub("^%%", "", 1) -- nikoberry: strip leading % if there is any
-	for i=0,#m -- strip ALL the leading spaces too.
+	for i=0,#m -- nikoberry: strip any leading percents and whitespace (same order as described)
+		m = m:gsub("^%%", "", 1)
 		m = m:gsub("^%s", "", 1)
 	end
 

--- a/SRC/LUA/CHAT.LUA
+++ b/SRC/LUA/CHAT.LUA
@@ -43,11 +43,10 @@ local function CHAT_Say(s, m, me)
 	for p in players.iterate do
 		if (gamestate ~= GS_LEVEL) or (p.spectator) or (MM.IsTimelineCorrect(s.mm.timetravel.timezone, p.mm.timetravel.timezone)) then
 			if (me) then
-				chatprintf(p, string.format("* %s%s\x80 %s", badge, s.name, m:sub(5))) --"/me" message
+				MM.Chatprint(p, string.format("* %s%s\x80 %s", badge, s.name, m:sub(5))) --"/me" message
 			else
-				chatprintf(p, string.format("%s<%s%s>\x80 %s", chatcolor, badge, s.name, m)) --Normal message
+				MM.Chatprint(p, string.format("%s<%s%s>\x80 %s", chatcolor, badge, s.name, m)) --Normal message
 			end
-			S_StartSound(nil, sfx_radio, p)
 		end
 	end
 
@@ -69,6 +68,11 @@ local chat_fmts = {
 }
 
 local function CHAT_TeamSay(s, m) --Sender (player_t), Message
+	m = m:gsub("^%%", "", 1) -- nikoberry: strip leading % if there is any
+	for i=0,#m -- strip ALL the leading spaces too.
+		m = m:gsub("^%s", "", 1)
+	end
+
 	local msg = string.format(chat_fmts[s.mm.role] or "[via SAYTEAM]<%s> %s", s.name, m)
 
 	for p in players.iterate do
@@ -76,8 +80,7 @@ local function CHAT_TeamSay(s, m) --Sender (player_t), Message
 			if (p.spectator) or (isdedicatedserver) or (s.mm.role == ROLE_MURDERER and p.mm.role == ROLE_MURDERER)
 			or ((s.mm.role == ROLE_SHERIFF or s.mm.role == ROLE_HERO or s.mm.role == ROLE_JESTERHERO)
 			and (p.mm.role == ROLE_SHERIFF or p.mm.role == ROLE_HERO or p.mm.role == ROLE_JESTERHERO)) then
-				chatprintf(p, msg)
-				S_StartSound(nil, sfx_radio, p)
+				MM.Chatprint(p, msg)
 			end
 		end
 	end
@@ -106,7 +109,7 @@ COM_AddCommand("SAYDEAD", function(p, ...) --sender, message
 	if (#m) then
 		--send the message
 		for p in players.iterate do
-			if (p.spectator) then chatprintf(p, string.format("\x86{%s} %s", sender, m)) end
+			if (p.spectator) then chatprintf(p, string.format("\x86{%s} %s", sender, m)) end -- nikoberry: not changed because dead chat is silent (if this gets changed after I added this comment im gonna shoot someone with a rail)
 		end
 		if (isdedicatedserver) then CONS_Printf(server, string.format("{%s} %s", sender, m)) end
 	else

--- a/SRC/LUA/CHAT.LUA
+++ b/SRC/LUA/CHAT.LUA
@@ -37,15 +37,15 @@ local function CHAT_Say(s, m, me)
 
 	--Admin/Verified badges
 	local badge = ""
-	if (s == server) then badge = "\x82~"..chatcolor
-	elseif (IsPlayerAdmin(s)) then badge = "\x82@"..chatcolor end
+	if (s == server) then badge = "^2~"..chatcolor
+	elseif (IsPlayerAdmin(s)) then badge = "^2@"..chatcolor end
 
 	for p in players.iterate do
 		if (gamestate ~= GS_LEVEL) or (p.spectator) or (MM.IsTimelineCorrect(s.mm.timetravel.timezone, p.mm.timetravel.timezone)) then
 			if (me) then
-				MM.Chatprint(p, string.format("* %s%s\x80 %s", badge, s.name, m:sub(5))) --"/me" message
+				MM.Chatprint(p, string.format("* %s%s^0 %s", badge, s.name, m:sub(5))) --"/me" message
 			else
-				MM.Chatprint(p, string.format("%s<%s%s>\x80 %s", chatcolor, badge, s.name, m)) --Normal message
+				MM.Chatprint(p, string.format("%s<%s%s>^0 %s", chatcolor, badge, s.name, m)) --Normal message
 			end
 		end
 	end
@@ -59,10 +59,10 @@ end
 -- SAYTEAM
 --
 
-local hero_fmt = "\x84[TEAM]\x82<%s>\x84 %s"
+local hero_fmt = "^4[TEAM]^2<%s>^4 %s"
 local chat_fmts = {
-	[ROLE_MURDERER]   = "\x85[TEAM]<%s> %s",
-	[ROLE_SHERIFF]    = "\x84[TEAM]<%s> %s",
+	[ROLE_MURDERER]   = "^5[TEAM]<%s> %s",
+	[ROLE_SHERIFF]    = "^4[TEAM]<%s> %s",
 	[ROLE_HERO]       = hero_fmt,
 	[ROLE_JESTERHERO] = hero_fmt,
 }
@@ -136,8 +136,8 @@ addHook("PlayerMsg", function(s, type, t, m) --source, type, target, msg
 			end,
 			[2] = function() --PM messages in different design for DEAD
 				if (t.spectator) then
-					MM.Chatprint(s, string.format("\x82[TO]\x86{%s}\x82 %s", t.name, m))
-					MM.Chatprint(t, string.format("\x82[PM]\x86{%s}\x82 %s", s.name, m))
+					MM.Chatprint(s, string.format("^2[TO]^6{%s}^2 %s", t.name, m))
+					MM.Chatprint(t, string.format("^2[PM]^6{%s}^2 %s", s.name, m))
 				else CONS_Printf(s, string.format("%s is alive, message not sent", t.name)) end
 			end
 		})

--- a/SRC/LUA/LIBRARIES/MICHAELMYERS.LUA
+++ b/SRC/LUA/LIBRARIES/MICHAELMYERS.LUA
@@ -221,7 +221,7 @@ end
 --nikoberry: Exists in case this ever gets used more than in MM.ChatPrint
 --also because this wouldn't be nice to read in MM.Chatprint
 MM.ShouldNotify = function()
-	return (CV_FindVar("chatnotifications").value ~= 0)
+	return (CV_FindVar("chatnotifications").value)
 end
 
 --chatprintf but safe for vanilla SRB2

--- a/SRC/LUA/LIBRARIES/MICHAELMYERS.LUA
+++ b/SRC/LUA/LIBRARIES/MICHAELMYERS.LUA
@@ -218,12 +218,18 @@ local carretToSRB2_color = function(s)
 	return str
 end
 
+--nikoberry: Exists in case this ever gets used more than in MM.ChatPrint
+--also because this wouldn't be nice to read in MM.Chatprint
+MM.ShouldNotify = function()
+	return (CV_FindVar("chatnotifications").value ~= 0)
+end
+
 --chatprintf but safe for vanilla SRB2
-MM.Chatprint = function(p, msg)
+MM.Chatprint = function(p, msg, forcesound)
 	--if (srb2classic) then
 		--chatprintf(p, msg)
 	--else
-		chatprintf(p, carretToSRB2_color(unicode.ascii(msg)))
+		chatprintf(p, carretToSRB2_color(unicode.ascii(msg)), ((forcesound or MM.ShouldNotify()) and not (CV_FindVar("chatmode").value == 2)))
 	--end
 end
 


### PR DESCRIPTION
Tl;dr:
"% " (and any leading whitespace after that) is stripped, so now it just looks like you did "`sayteam blahblahblah`" or teamtalked.
chat no longer pulls the strings and makes the phone ring even if you have chatnotifs off or the window hidden. (You can bypass chatnotifs via new param (meant to be bool) added to `MM.Chatprint`, but not hidden window)